### PR TITLE
Add before after image slider + tests

### DIFF
--- a/blocks/before-after-slider/before-after-slider.css
+++ b/blocks/before-after-slider/before-after-slider.css
@@ -1,0 +1,89 @@
+:root {
+  --before-after-slider-width: min(80vw, 746px);
+  --before-after-slider-input-width: 50px;
+  --before-after-slider-color: white;
+}
+
+.before-after-slider {
+  position: relative;
+  width: var(--before-after-slider-width);
+  overflow: hidden;
+}
+
+.before-after-slider img {
+  display: block;
+  width: var(--before-after-slider-width);
+  height: auto;
+  object-fit: cover;
+  pointer-events: none;
+  user-select: none;
+}
+
+.before-after-slider .after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 50%;
+  height: 100%;
+  overflow: hidden;
+  z-index: 1;
+}
+
+.before-after-slider .after img {
+  position: absolute;
+  max-width: unset;
+  top: 0;
+  right: 0;
+  height: 100%;
+}
+
+.before-after-slider .slider {
+  position: absolute;
+  top: 0;
+  left: calc(50% - var(--before-after-slider-input-width)/2);
+  width: var(--before-after-slider-input-width);
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  user-select: none;
+  z-index: 2;
+}
+
+.before-after-slider .slider .separator {
+  width: 2px;
+  flex-grow: 1;
+  background-color: var(--before-after-slider-color);
+}
+
+.before-after-slider .slider-input {
+  width: var(--before-after-slider-input-width);
+  height: var(--before-after-slider-input-width);
+  color: var(--before-after-slider-color);
+  border: 2px solid var(--before-after-slider-color);;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: space-evenly;
+}
+
+.before-after-slider .slider .slider-input:before {
+  content: "";
+  padding: 4px;
+  display: inline-block;
+  border: solid var(--before-after-slider-color);
+  border-width: 0 4px 4px 0;
+  transform: rotate(135deg);
+  margin-left: 6px;
+}
+
+.before-after-slider .slider .slider-input:after {
+  content: "";
+  padding: 4px;
+  display: inline-block;
+  border: solid var(--before-after-slider-color);
+  border-width: 0 4px 4px 0;
+  transform: rotate(-45deg);
+  margin-right: 6px;
+}

--- a/blocks/before-after-slider/before-after-slider.js
+++ b/blocks/before-after-slider/before-after-slider.js
@@ -1,0 +1,90 @@
+
+export default function decorate(block) {
+  
+  /*
+   * build container elements
+   */
+
+  block.classList.add('content');
+
+  // get original images
+  const imageEls = block.querySelectorAll('img');
+  let img1El = imageEls[0];
+  let img2El = imageEls[1];
+
+  // reset block content to dry slider input
+  block.innerHTML = sliderInput;
+
+  // add after image element
+  let afterDiv = document.createElement('div');
+  afterDiv.classList.add('after');
+  let afterImg = document.createElement('img');
+  afterImg.src = img2El.src;
+  afterDiv.append(afterImg);
+  block.prepend(afterDiv);
+  
+  // add before image element
+  block.prepend(img1El);
+
+  /*
+   * add js animation
+   */
+
+  const slider = block;
+  const sliderImgWrapper = block.querySelector(":scope > .after");
+  const sliderHandle = block.querySelector(":scope > .slider");
+  
+  slider.addEventListener("mousemove", sliderMouseMove);
+  slider.addEventListener("touchmove", sliderMouseMove);
+  
+  let locked = true;
+  
+  slider.addEventListener("mousedown", sliderMouseDown);
+  slider.addEventListener("touchstart", sliderMouseDown);
+  slider.addEventListener("mouseup", sliderMouseUp);
+  slider.addEventListener("touchend", sliderMouseUp);
+  slider.addEventListener("mouseleave", sliderMouseLeave);
+  
+  function sliderMouseMove(event) {
+    if(locked) {
+      return;
+    } 
+  
+    const sliderLeftX = slider.offsetLeft;
+    const sliderWidth = slider.clientWidth;
+    const sliderHandleWidth = sliderHandle.clientWidth;
+  
+    let mouseX = (event.clientX || event.touches[0].clientX) - sliderLeftX;
+    if(mouseX < 0) mouseX = 0;
+    else if(mouseX > sliderWidth) mouseX = sliderWidth;
+  
+    sliderImgWrapper.style.width = `${((1 - mouseX/sliderWidth) * 100).toFixed(4)}%`;
+    sliderHandle.style.left = `calc(${((mouseX/sliderWidth) * 100).toFixed(4)}% - ${sliderHandleWidth/2}px)`;
+  }
+    
+  function sliderMouseDown(event) {
+    if(locked) {
+      locked = false;
+    } 
+    sliderMouseMove(event);
+  }
+  
+  function sliderMouseUp() {
+    if(!locked) {
+      locked = true;
+    } 
+  }
+  
+  function sliderMouseLeave() {
+    if(locked) {
+      locked = false;
+    }
+  }
+
+}
+
+const sliderInput = `<div class="slider">
+  <div class="separator"></div>
+  <div class="slider-input"></div>
+  <div class="separator"></div>
+</div>`;

--- a/test/blocks/before-after-slider/before-after-slider.test.js
+++ b/test/blocks/before-after-slider/before-after-slider.test.js
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+
+const { default: decorate } = await import('../../../blocks/before-after-slider/before-after-slider.js');
+
+describe('before/after image slider', () => {
+
+  it('renders a before/after image slider', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    decorate(document.querySelector('.before-after-slider'));
+
+    expect(document.querySelector('.before-after-slider')).to.exist;
+    expect(document.querySelector('.before-after-slider .after')).to.exist;
+    expect(document.querySelector('.before-after-slider .slider')).to.exist;
+  });
+
+  it('slildes on mouse down', async () => {
+    // init block
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const el = document.querySelector('.before-after-slider');
+    decorate(el);
+    
+    // get image client width before mouse move
+    let afterImgEl = document.querySelector('.before-after-slider .after');
+    const originalAfterImgW = afterImgEl.clientWidth;
+
+    // dispatch mouse down event to force sliding
+    const event = new MouseEvent('mousedown', {
+      'view': window,
+      'bubbles': true,
+      'cancelable': true,
+      'clientX': 100,
+      'clientY': 100
+    });
+    el.dispatchEvent(event);
+    
+    // get image client width after mouse move
+    const afterMoveAfterImgW = afterImgEl.clientWidth;
+
+    expect(originalAfterImgW).to.be.above(afterMoveAfterImgW);
+  });
+
+  it('stops sliding on mouse up', async () => {
+    // init block
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const el = document.querySelector('.before-after-slider');
+    decorate(el);
+    
+    // get image client width before mouse move
+    let afterImgEl = document.querySelector('.before-after-slider .after');
+    const originalAfterImgW = afterImgEl.clientWidth;
+
+    // dispatch mouse down event to force sliding
+    let event = new MouseEvent('mousedown', {
+      'view': window,
+      'bubbles': true,
+      'cancelable': true,
+      'clientX': 100,
+      'clientY': 100
+    });
+    el.dispatchEvent(event);
+    
+    // get image client width after mouse move
+    const afterMoveAfterImgW = afterImgEl.clientWidth;
+
+    expect(originalAfterImgW).to.be.above(afterMoveAfterImgW);
+
+    // dispatch mouse down event to force sliding
+    event = new MouseEvent('mouseup', {
+      'view': window,
+      'bubbles': true,
+      'cancelable': true,
+      'clientX': 100,
+      'clientY': 100
+    });
+    el.dispatchEvent(event);
+
+    // dispatch mouse down event to force sliding
+    event = new MouseEvent('mousemove', {
+      'view': window,
+      'bubbles': true,
+      'cancelable': true,
+      'clientX': 300,
+      'clientY': 150
+    });
+    el.dispatchEvent(event);
+
+    expect(afterMoveAfterImgW).to.be.equal(afterImgEl.clientWidth);
+
+  });
+
+  it('unlocks the slider on mouseleave', async () => {
+    // init block
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const el = document.querySelector('.before-after-slider');
+    decorate(el);
+    
+    // get image client width before mouse move
+    let afterImgEl = document.querySelector('.before-after-slider .after');
+    const originalAfterImgW = afterImgEl.clientWidth;
+
+    // dispatch mouse down event to force sliding
+    let event = new MouseEvent('mousedown', {
+      'view': window,
+      'bubbles': true,
+      'cancelable': true,
+      'clientX': 100,
+      'clientY': 100
+    });
+    el.dispatchEvent(event);
+    
+    // get image client width after mouse move
+    const afterMoveAfterImgW = afterImgEl.clientWidth;
+
+    expect(originalAfterImgW).to.be.above(afterMoveAfterImgW);
+
+    // dispatch mouse down event to force sliding
+    event = new MouseEvent('mouseup', {
+      'view': window,
+      'bubbles': true,
+      'cancelable': true,
+      'clientX': 100,
+      'clientY': 100
+    });
+    el.dispatchEvent(event);
+
+    // dispatch mouse down event to force sliding
+    event = new MouseEvent('mouseleave', {
+      'view': window,
+      'bubbles': true,
+      'cancelable': true
+    });
+    el.dispatchEvent(event);
+
+    // dispatch mouse down event to force sliding
+    event = new MouseEvent('mousedown', {
+      'view': window,
+      'bubbles': true,
+      'cancelable': true,
+      'clientX': 10,
+      'clientY': 100
+    });
+    el.dispatchEvent(event);
+
+    expect(afterMoveAfterImgW).to.be.below(afterImgEl.clientWidth);
+
+  });
+
+});

--- a/test/blocks/before-after-slider/mocks/default.html
+++ b/test/blocks/before-after-slider/mocks/default.html
@@ -1,0 +1,16 @@
+<div class="before-after-slider">
+  <div>
+    <div>
+      <picture>
+        <img id="before-img" src="./media_1b35286a4e655d32c0e7c9e6a08fdff91c1f7b603.png?width=750&#x26;format=png&#x26;optimize=medium">
+      </picture>
+    </div>
+  </div>
+  <div>
+    <div>
+      <picture>
+        <img id="after-img" src="./media_1d0945bf6db2ee76b29b545495e7fd8cf41420084.png?width=750&#x26;format=png&#x26;optimize=medium">
+      </picture>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Implements an image comparison block with an interactive slider.
This PR also adds unit test for the block code.

Original HelpX Internal page: https://helpx-internal.corp.adobe.com/content/help/en/internal/alp/digital-imaging/20203.html

Sharepoint doc: /import-tests/content/help/en/internal/alp/digital-imaging/20203.docx

URL for testing:

- https://add-block-before-after-slider--helpx-internal--adobecom.hlx.page/import-tests/content/help/en/internal/alp/digital-imaging/20203