### PR TITLE
MWPW-128520 Enable sidekick localize and pre-flight plugins from Milo

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -3,6 +3,15 @@
   "host": "helpx-internal.corp.adobe.com",
   "plugins": [
     {
+      "id": "localize",
+      "title": "Localize",
+      "environments": [ "edit" ],
+      "url": "https://milo.adobe.com/tools/loc/index.html?project=milo--adobecom",
+      "passReferrer": true,
+      "excludePaths": [ "/**" ],
+      "includePaths": [ "**/:x**" ]
+    },
+    {
       "id": "library",
       "title": "Library",
       "environments": [ "edit" ],
@@ -11,6 +20,12 @@
       "paletteRect": "top: auto; bottom: 20px; left: 20px; height: 398px; width: 360px;",
       "url": "https://milo.adobe.com/tools/library",
       "includePaths": [ "**.docx**" ]
+    },
+    {
+      "title": "Preflight",
+      "id": "preflight",
+      "environments": ["dev", "preview", "live"],
+      "event": "preflight"
     }
   ]
 }


### PR DESCRIPTION
This PR would enable the sidekick plugins like localization which is needed to test the Milo localization flow on the HelpX internal space.