### PR TITLE
MWPW-126051 [Milo Block] Viewport Specific Container

### DIFF
--- a/blocks/before-after-slider/before-after-slider.css
+++ b/blocks/before-after-slider/before-after-slider.css
@@ -6,6 +6,7 @@
   position: relative;
   display: grid;
   overflow: hidden;
+  max-width: fit-content;
 }
 
 .before-after-slider > .image {

--- a/blocks/generic/generic.js
+++ b/blocks/generic/generic.js
@@ -1,0 +1,1 @@
+export default (block) => block;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -129,8 +129,6 @@ footer {
 .layout-container {
   max-width: 1200px;
   margin: 0 auto;
-  display: flex;
-  justify-content: center;
   gap: 60px;
 }
 
@@ -160,4 +158,26 @@ footer {
 
 .on-this-page a {
   margin-left: 15px;
+}
+
+
+/* phone */
+@media screen and (max-width: 37.4375rem) {
+  .hidden-mobile {
+    display: none !important;
+  }
+}
+
+/* tablet */ 
+@media screen and (min-width: 37.5rem) and (max-width: 74.9375rem) {
+  .hidden-tablet {
+    display: none !important;
+  }
+}
+
+/* desktop */
+@media screen and (min-width: 75rem) { 
+  .hidden-desktop {
+    display: none !important;
+  }
 }

--- a/test/blocks/generic/generic.test.js
+++ b/test/blocks/generic/generic.test.js
@@ -1,0 +1,15 @@
+/* eslint-disable no-unused-expressions */
+import { expect } from '@esm-bundle/chai';
+
+const { default: decorate } = await import('../../../blocks/generic/generic.js');
+
+const initialHTML = '<div class="generic"><div></div></div>';
+document.body.innerHTML = initialHTML;
+const generic = document.querySelectorAll('.generic');
+[...generic].forEach(decorate);
+
+describe('generic', () => {
+  it('should do absolutely nothing', async () => {
+    expect(document.body.innerHTML).to.equal(initialHTML);
+  });
+});

--- a/tools/importer/import.js
+++ b/tools/importer/import.js
@@ -16,19 +16,19 @@
   import rules
 */
 
-import transformNotes from "./rules/notes.js";
-import createMetadataBlock from "./rules/metadata.js";
-import createAccordionBlocks from "./rules/accordions.js";
-import createFeedbackBlock from "./rules/feedback.js";
-import createTitleBlock from "./rules/title.js";
-import createDescriptionBlock from "./rules/description.js";
-import createInternalBannerBlock from "./rules/internal-banner.js";
-import createTableBlocks from "./rules/tables.js";
-import createToCBlock from "./rules/toc.js";
-import createColumnsFromDexterFlexContainers from "./rules/dexter-flexcontainers.js";
-import createBeforeAfterSliders from "./rules/before-and-after.js";
-import createVideosEmbed from "./rules/videos.js";
-
+import createAccordionBlocks from './rules/accordions.js';
+import createBeforeAfterSliders from './rules/before-and-after.js';
+import createDescriptionBlock from './rules/description.js';
+import createColumnsFromDexterFlexContainers from './rules/dexter-flexcontainers.js';
+import createFeedbackBlock from './rules/feedback.js';
+import createInternalBannerBlock from './rules/internal-banner.js';
+import createMetadataBlock from './rules/metadata.js';
+import transformNotes from './rules/notes.js';
+import createTableBlocks from './rules/tables.js';
+import createTitleBlock from './rules/title.js';
+import createToCBlock from './rules/toc.js';
+import createVideosEmbed from './rules/videos.js';
+import handleViewportSpecific from './rules/viewportSpecific.js';
 
 export default {
   /**
@@ -69,10 +69,22 @@ export default {
     createToCBlock(main, document);
 
     createColumnsFromDexterFlexContainers(main, document);
-  
+
     createBeforeAfterSliders(main, document);
 
     createVideosEmbed(main, document);
+
+    // NOTE: the import scripts for specific blocks need to check if they should be hidden
+    // by checking themselves and their parents for '.hidden-desktop',
+    // 'hidden-tablet', and '.hidden-mobile'
+    // TODO: create an abstraction that eliminates repeated code across import scripts,
+    // since there's a lot of it.
+
+    // This function must run at the very end because it might change something
+    // that should be a block to just text, so make sure all the blocks we
+    // need have already been created when we get to this function.
+    // It checks if something's a block by looking for a <tr> element
+    handleViewportSpecific(document);
 
     /*
       clean

--- a/tools/importer/rules/viewportSpecific.js
+++ b/tools/importer/rules/viewportSpecific.js
@@ -1,0 +1,21 @@
+const handleViewportSpecific = (document) => {
+  const viewPortSpecificContainers = document.querySelectorAll('.viewportSpecificContainer');
+  viewPortSpecificContainers.forEach((container) => {
+    const viewports = ['hidden-desktop', 'hidden-tablet', 'hidden-mobile']
+      .filter((viewport) => !!container.querySelector(`.${viewport}`));
+
+    if (viewports.length) {
+      if (!container.querySelector('tr')) { // if it's not already a block
+        const cells = [
+          [`generic (${viewports.join(', ')})`],
+          [container.textContent],
+        ];
+        const table = WebImporter.DOMUtils.createTable(cells, document);
+        container.insertAdjacentElement('beforebegin', table);
+        container.remove();
+      }
+    }
+  });
+};
+
+export default handleViewportSpecific;


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/MWPW-126051

[docx file](https://adobe.sharepoint.com/:w:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7BAD60BE2F-6755-4D2A-B391-B8893D7053AA%7D&file=before-after-test1.docx&action=default&mobileredirect=true)

test url: https://viewport--helpx-internal--adobecom.hlx.page/content/help/en/internal/viewport-test

A few notes:
- the main changes are css only. They only make it so certain classnames (that can be added to blocks in word) are hidden in certain viewport sizes. 
- A generic block that does nothing was added so that users have the ability to add classnames to arbitrary bits of content
- The import script for viewportspecific containers were written to be run after all the other blocks have been imported. This is because we cannot have blocks within blocks so any blocks inside the container are expected to have been turned into tables already with the relevant `.hidden-[viewport]` classes. This is just to handle regular (non-block) content that happens to be hidden in some viewport sizes. 