### PR TITLE
MWPW-192736: Add check for milolibs query param

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -33,6 +33,7 @@ export const [setLibs, getLibs] = (() => {
         return libs;
       }
       const branch = new URLSearchParams(window.location.search).get('milolibs') || 'main';
+      if (!/^[a-zA-Z0-9_-]+$/.test(branch)) throw new Error('Invalid branch name.');
       if (branch === 'local') return 'http://localhost:6456/libs';
       if (branch.indexOf('--') > -1) return `https://${branch}.aem.page/libs`;
       return `https://${branch}--milo--adobecom.aem.page/libs`;


### PR DESCRIPTION
Whitelist branch parameter with `/^[a-zA-Z0-9_-]+$/`; throw on any other characters.

## Ticket
https://jira.corp.adobe.com/browse/MWPW-192736

## Test URLs
Before: https://main--helpx-internal--adobecom.aem.page/
After: https://MWPW-192736--helpx-internal--zagi25.aem.page/

---
_This PR was generated by Claude (Anthropic's Claude Code CLI)._